### PR TITLE
Changed Int to Long

### DIFF
--- a/app/src/main/java/com/example/pennywise/AddTransactionActivity.kt
+++ b/app/src/main/java/com/example/pennywise/AddTransactionActivity.kt
@@ -31,17 +31,18 @@ class AddTransactionActivity : AppCompatActivity() {
         radioGroup = findViewById(R.id.radio_group)
         amountEditText = findViewById(R.id.amountEditText)
 
-//<<<<<<< HEAD
+
         // The amount transferred from CameraScannerActivity
+        // Needs to be fixed - if nothing is added in CameraScannerActivity, the app crashes!
         val scannedAmount = intent.getIntExtra("Amount",0)
         if (scannedAmount > 0) {
             amountEditText.setText(scannedAmount.toString())
         }
-//=======
+
         //This limits the input to two decimal places
         amountEditText.addDecimalLimiter()
 
-//>>>>>>> main
+
 
         val returnButton = findViewById<ImageButton>(R.id.returnIB)
         returnButton.setOnClickListener {
@@ -88,8 +89,8 @@ class AddTransactionActivity : AppCompatActivity() {
     /**
      * Converts the amount input to ören. Replaces amount2()
      */
-    private fun convertAmount(): Int {
-        return (amountEditText.text.toString().toFloat() * 100).toInt()
+    private fun convertAmount(): Long {
+        return (amountEditText.text.toString().toFloat() * 100).toLong()
     }
 
 
@@ -139,7 +140,9 @@ class AddTransactionActivity : AppCompatActivity() {
     fun decimalLimiter(string: String, MAX_DECIMAL: Int): String {
 
         var inputString = string
-        if (inputString[0] == '.') inputString = "0$inputString"
+        if (inputString[0].toString() == getString(R.string.decimal_delimiter)) {
+            inputString = "0$inputString"
+        }
         val max = inputString.length
 
         var rFinal = ""
@@ -149,16 +152,18 @@ class AddTransactionActivity : AppCompatActivity() {
         var decimal = 0
         var t: Char
 
-        val decimalCount = inputString.count{ ".".contains(it) }
+        val decimalCount = inputString.count{
+            getString(R.string.decimal_delimiter).contains(it)
+        }
 
         if (decimalCount > 1)
             return inputString.dropLast(1)
 
         while (i < max) {
             t = inputString[i]
-            if (t != '.' && !after) {
+            if (t.toString() != getString(R.string.decimal_delimiter) && !after) {
                 up++
-            } else if (t == '.') {
+            } else if (t.toString() == getString(R.string.decimal_delimiter)) {
                 after = true
             } else {
                 decimal++

--- a/app/src/main/java/com/example/pennywise/Balance.kt
+++ b/app/src/main/java/com/example/pennywise/Balance.kt
@@ -1,4 +1,4 @@
 package com.example.pennywise
 
-data class Balance(var kronor: Int = 0,
-                   var ore: Int = 0)
+data class Balance(var kronor: Long = 0,
+                   var ore: Long = 0)

--- a/app/src/main/java/com/example/pennywise/CameraScannerActivity.kt
+++ b/app/src/main/java/com/example/pennywise/CameraScannerActivity.kt
@@ -22,7 +22,8 @@ class CameraScanner : AppCompatActivity() {
 
 
             val intent = Intent(this, AddTransactionActivity::class.java)
-            intent.putExtra("Amount",input.text.toString().toInt())
+            // We need to check this! Doesn't play well with DecimalLimiter.
+            intent.putExtra("Amount",input.text.toString().toLong())
             Log.d("!!!","amount before startactivity = ${input.text.toString().toInt()}")
             finish()
             startActivity(intent)

--- a/app/src/main/java/com/example/pennywise/DataHandler.kt
+++ b/app/src/main/java/com/example/pennywise/DataHandler.kt
@@ -41,7 +41,7 @@ object DataHandler {
 
     fun makeListAndBalance(documentSnapShot: QuerySnapshot) {
         itemsToView.clear()
-        var sum = 0
+        var sum : Long = 0
         for (document in documentSnapShot.documents) {
             val item = document.toObject<Transaction>()
             if (item != null) {

--- a/app/src/main/java/com/example/pennywise/Transaction.kt
+++ b/app/src/main/java/com/example/pennywise/Transaction.kt
@@ -4,7 +4,7 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
-data class Transaction (val amount: Int = 0,
+data class Transaction (val amount: Long = 0,
                         val category: String = "",
                         //Auto-timestamp
                         val timeStamp: String = DateTimeFormatter

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="to_log_in">Please enter e-mail and password to log in</string>
     <string name="user_logged_in">User logged in</string>
     <string name="user_not_logged_in">User not logged in</string>
+    <string name="decimal_delimiter">.</string>
 </resources>


### PR DESCRIPTION
Changed Int to Long in Transaction, so the app can keep track of MILLIONS AND BILLIONS without embarrassing errors. Also moved the decimal "." in decimalLimiter() to string resources; this way, when we add a string resource for Swedish, the app should use "," instead. This hasn't been done yet, though.
(Oh, I just realized I forgot to change how the balance is shown in OverViewActivity - it still uses "," even though you have to use "." when adding a transaction.)